### PR TITLE
fix kindeitor create options

### DIFF
--- a/lib/rails_kindeditor/helper.rb
+++ b/lib/rails_kindeditor/helper.rb
@@ -22,36 +22,19 @@ module RailsKindeditor
     private
     def js_replace(dom_id, options = {})
       js_options = get_options(options)
+      js_options.merge(:uploadJson => '/kindeditor/upload', :fileManagerJson => '/kindeditor/filemanager')
       "KindEditor.ready(function(K){
-      	K.create('##{dom_id}', {
-      		#{js_options},
-      		uploadJson: '/kindeditor/upload',
-      		fileManagerJson: '/kindeditor/filemanager'
-      	});
+      	K.create('##{dom_id}', #{js_options.to_json});
       });"
     end
 
     def get_options(options)
-      str = []
       options.delete(:uploadJson)
       options.delete(:fileManagerJson)
       options.reverse_merge!(:width => '100%')
       options.reverse_merge!(:height => 300)
       options.reverse_merge!(:allowFileManager => true)
-      options.each do |key, value|
-        item = case value
-          when String then
-            value.split(//).first == '^' ? value.slice(1..-1) : "'#{value}'"
-          when Hash then
-            "{ #{get_options(value)} }"
-          when Array then 
-            arr = value.collect { |v| "'#{v}'" }
-            "[ #{arr.join(',')} ]"
-          else value
-        end
-        str << %Q{"#{key}": #{item}}
-      end
-      str.sort.join(',')
+      options
     end
   end
   


### PR DESCRIPTION
When I put  `colortable` option whose value is nested array (see http://www.kindsoft.net/docs/option.html#colortable ) , Kindeditor fails to create. 

Then I figured out that some of kindeditor's  `create` options come from ruby data structure, which are converted to javascript string one by one in the helper. But it does not handle nesetd array well. In fact the options are just JSON data. Variables of hash, array or string can be converted to JSON format by `#to_json`.  So I fix it.
