### PR TITLE
fix unknown filter type: #<Pathname..>

### DIFF
--- a/lib/rails_kindeditor.rb
+++ b/lib/rails_kindeditor.rb
@@ -32,10 +32,10 @@ module RailsKindeditor
   def self.root_path
     @root_path ||= Pathname.new(File.dirname(File.expand_path('../', __FILE__)))
   end
-  
+
   def self.assets
     Dir[root_path.join('vendor/assets/javascripts/kindeditor/**', '*.{js,css}')].inject([]) do |assets, path|
-      assets << Pathname.new(path).relative_path_from(root_path.join('vendor/assets/javascripts'))
+      assets << Pathname.new(path).relative_path_from(root_path.join('vendor/assets/javascripts')).to_s
     end
   end
   


### PR DESCRIPTION
```shell
rake assets:precompile
```

```
rake aborted!
TypeError: unknown filter type: #<Pathname:kindeditor/kindeditor.js>
/Users/plusor/.rvm/gems/ruby-2.2.1@owhat/gems/sprockets-3.2.0/lib/sprockets/legacy.rb:296:in `compile_match_filter'
/Users/plusor/.rvm/gems/ruby-2.2.1@owhat/gems/sprockets-3.2.0/lib/sprockets/manifest.rb:125:in `block in find'
/Users/plusor/.rvm/gems/ruby-2.2.1@owhat/gems/sprockets-3.2.0/lib/sprockets/manifest.rb:125:in `map'
/Users/plusor/.rvm/gems/ruby-2.2.1@owhat/gems/sprockets-3.2.0/lib/sprockets/manifest.rb:125:in `find'
/Users/plusor/.rvm/gems/ruby-2.2.1@owhat/gems/sprockets-3.2.0/lib/sprockets/manifest.rb:162:in `compile'
/Users/plusor/.rvm/gems/ruby-2.2.1@owhat/gems/sprockets-rails-2.3.1/lib/sprockets/rails/task.rb:70:in `block (3 levels) in define'
/Users/plusor/.rvm/gems/ruby-2.2.1@owhat/gems/sprockets-3.2.0/lib/rake/sprocketstask.rb:147:in `with_logger'
/Users/plusor/.rvm/gems/ruby-2.2.1@owhat/gems/sprockets-rails-2.3.1/lib/sprockets/rails/task.rb:69:in `block (2 levels) in define'
Tasks: TOP => assets:precompile
(See full trace by running task with --trace)
```