### PR TITLE
fix DEPRECATION WARNING

### DIFF
--- a/lib/rails_kindeditor/simple_form.rb
+++ b/lib/rails_kindeditor/simple_form.rb
@@ -1,7 +1,7 @@
 module RailsKindeditor
   module SimpleForm
     class KindeditorInput < ::SimpleForm::Inputs::Base
-      def input
+      def input(wrapper_options)
         @builder.kindeditor(attribute_name, input_html_options)
       end
     end


### PR DESCRIPTION
在simple_form内使用rails_kindeditor的时候，simple_form会有如下输出。

```
DEPRECATION WARNING: input method now accepts a `wrapper_options` argument. The method definition without the argument is deprecated and will be removed in the next Simple Form version. Change your code from:

    def input

to

    def input(wrapper_options)

See https://github.com/plataformatec/simple_form/pull/997 for more information.

```

wrapper_options是用来传input的wrapper参数的。

比如我们这样定义input `ba.use :input, class: 'form-control'`
`wrapper_options`就会是 {class: 'form-control'}

即使使用`ba.use :input`，也不会报错。
