### PR TITLE
This file 'carrierwave/processing/mime_types' needn't any more

### DIFF
--- a/app/uploaders/kindeditor/asset_uploader.rb
+++ b/app/uploaders/kindeditor/asset_uploader.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'carrierwave/processing/mime_types'
-
 class Kindeditor::AssetUploader < CarrierWave::Uploader::Base
   
   EXT_NAMES = {:image => RailsKindeditor.upload_image_ext,


### PR DESCRIPTION
Remove `CarrierWave::MimeTypes` processor module
Since #1245 (*), CarrierWave::MimeTypes module is redundant as
`mime-types` gem is a runtime dependency now, and `SanitizedFile` gets
it's content_type using it.
The module was *deprecated* since 0.10 and warned developers when used it.